### PR TITLE
fix: push tag to remote before gh release create

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,9 +49,11 @@ jobs:
         with:
           version: "latest"
 
-      - name: Create local tag
+      - name: Create and push tag
         if: steps.check.outputs.skip == 'false'
-        run: git tag "${{ steps.version.outputs.tag }}"
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Build package
         if: steps.check.outputs.skip == 'false'
@@ -62,14 +64,8 @@ jobs:
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
-            --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload release artifacts
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          gh release upload "${{ steps.version.outputs.tag }}" dist/*
+            --generate-notes \
+            dist/*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The previous fix created the tag locally (so hatch-vcs produces a clean version) but didn't push it to the remote
- `gh release create` requires the tag to exist on the remote, so it failed with: `tag v0.2.3 exists locally but has not been pushed`
- Now the tag is pushed to the remote immediately after local creation
- Also simplified: `dist/*` artifacts are attached directly in the `gh release create` step instead of a separate upload step

## Step order

1. Compute next version
2. Install uv
3. `git tag` + `git push origin` (tag exists locally for hatch-vcs AND on remote for gh)
4. `uv build` (produces clean version)
5. `gh release create` with `dist/*` attached
6. `uv publish` to PyPI